### PR TITLE
Revert "Bump google.com/cloudsdktool/google-cloud-cli from 522.0.0-emulators to 523.0.0-emulators"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:523.0.0-emulators
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:522.0.0-emulators
 
 ENV DATABASE_MODE=firestore-native
 


### PR DESCRIPTION
Reverts 178inaba/firestore-emulator-container-image#58