### PR TITLE
Rename publish workflow names for consistency

### DIFF
--- a/.github/workflows/firestore-publish.yml
+++ b/.github/workflows/firestore-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Firestore Docker Image
+name: Publish Firestore Emulator
 
 on:
   push:

--- a/.github/workflows/pubsub-publish.yml
+++ b/.github/workflows/pubsub-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Pub/Sub Docker Image
+name: Publish Pub/Sub Emulator
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Cloud Emulators
 
-[![Publish Firestore Docker Image](https://github.com/178inaba/gcloud-emulators/actions/workflows/firestore-publish.yml/badge.svg)](https://github.com/178inaba/gcloud-emulators/actions/workflows/firestore-publish.yml)
-[![Publish Pub/Sub Docker Image](https://github.com/178inaba/gcloud-emulators/actions/workflows/pubsub-publish.yml/badge.svg)](https://github.com/178inaba/gcloud-emulators/actions/workflows/pubsub-publish.yml)
+[![Publish Firestore Emulator](https://github.com/178inaba/gcloud-emulators/actions/workflows/firestore-publish.yml/badge.svg)](https://github.com/178inaba/gcloud-emulators/actions/workflows/firestore-publish.yml)
+[![Publish Pub/Sub Emulator](https://github.com/178inaba/gcloud-emulators/actions/workflows/pubsub-publish.yml/badge.svg)](https://github.com/178inaba/gcloud-emulators/actions/workflows/pubsub-publish.yml)
 
 ## Firestore / Datastore Emulator
 


### PR DESCRIPTION
## Summary
Replace "Docker Image" with "Emulator" in publish workflow `name` fields and README badge text to align with the file naming convention.

## Changes
- `firestore-publish.yml`: `Publish Firestore Docker Image` → `Publish Firestore Emulator`
- `pubsub-publish.yml`: `Publish Pub/Sub Docker Image` → `Publish Pub/Sub Emulator`
- `README.md`: Update badge text accordingly

Closes #108