### PR TITLE
Use GH_TOKEN instead of GITHUB_TOKEN in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Enable auto-merge for Dependabot PRs
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr review --approve "${PR_URL}"
           gh pr merge --auto --merge "${PR_URL}"


### PR DESCRIPTION
## Summary

Fix the auto-merge Dependabot workflow by using `GH_TOKEN` instead of `GITHUB_TOKEN` as the environment variable for the GitHub App token. The `GITHUB_TOKEN` name conflicts with the built-in GitHub Actions token, causing the `gh` CLI to use the wrong token.

Closes #113