### PR TITLE
Improve Dockerfile signal handling and health check

### DIFF
--- a/firestore/Dockerfile
+++ b/firestore/Dockerfile
@@ -4,7 +4,6 @@ ENV DATABASE_MODE=firestore-native
 
 EXPOSE 8080
 
-HEALTHCHECK CMD curl -f localhost:8080 || exit 1
-STOPSIGNAL SIGKILL
+HEALTHCHECK CMD curl -f localhost:8080
 
-CMD ["sh", "-c", "gcloud emulators firestore start --database-mode $DATABASE_MODE --host-port 0.0.0.0:8080"]
+CMD ["sh", "-c", "exec gcloud emulators firestore start --database-mode $DATABASE_MODE --host-port 0.0.0.0:8080"]

--- a/pubsub/Dockerfile
+++ b/pubsub/Dockerfile
@@ -2,7 +2,6 @@ FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:555.0.0-emulators
 
 EXPOSE 8085
 
-HEALTHCHECK CMD curl -f localhost:8085 || exit 1
-STOPSIGNAL SIGKILL
+HEALTHCHECK CMD curl -f localhost:8085
 
 CMD ["gcloud", "beta", "emulators", "pubsub", "start", "--host-port=0.0.0.0:8085"]


### PR DESCRIPTION
## Summary
- Add `exec` to Firestore `CMD` so the `gcloud` process becomes PID 1 and receives signals directly
- Remove `STOPSIGNAL SIGKILL` from both Dockerfiles as it is no longer needed with `exec` in place
- Remove redundant `|| exit 1` from `HEALTHCHECK` in both Dockerfiles since `curl -f` already returns a non-zero exit code on failure

Closes #115